### PR TITLE
`ctrl-c` でインサートモードを抜けてもポップアップが消えるように変更

### DIFF
--- a/autoload/skkeleton_state_popup.vim
+++ b/autoload/skkeleton_state_popup.vim
@@ -18,7 +18,7 @@ function! skkeleton_state_popup#enable() abort
       autocmd InsertEnter * call s:create_or_update_popup()
     endif
     autocmd User skkeleton-handled if mode() =~# '^i' | call s:create_or_update_popup() | endif
-    autocmd InsertLeave * call s:close_popup()
+    autocmd ModeChanged i*:n* call s:close_popup()
   augroup END
 endfunction
 


### PR DESCRIPTION
`autocmd InsertLeave * call s:close_popup()` でインサートモードを抜けるときにポップアップを閉じていますが、`ctrl-c` でインサートモードを抜けると `InsertLeave` イベントが発火しません。
そこで、`ModeChanged` イベントを使って `ctrl-c` でインサートモードを抜けてもポップアップが閉じられるようにしました。