### PR TITLE
fix: Popup buffers are not properly deleted

### DIFF
--- a/autoload/skkeleton_state_popup.vim
+++ b/autoload/skkeleton_state_popup.vim
@@ -93,7 +93,7 @@ function! s:close_popup_in_nvim() abort
       " The `:bwipeout` command is not allowed in cmdwin.  Postpone buffer
       " removal after leaving cmdwin.
       execute printf(
-        \ 'autocmd CmdwinLeave * call timer_start(0, { _ -> "bwipeout! %d" })',
+        \ 'autocmd CmdwinLeave * ++once call timer_start(0, { _ -> execute("bwipeout! %d") })',
         \ s:buf)
     endif
     call remove(s:, 'buf')


### PR DESCRIPTION
### Problem

On Neovim, buffers for popups are not deleted properly if they are created while in cmdwin because the definition of the autocmd to remove them is wrong: https://github.com/NI57721/skkeleton-state-popup/blob/2a72e33c47cc8762517d479c28f0deedde8b6794/autoload/skkeleton_state_popup.vim#L95-L97

In addition, the autocmds that set up to remove the buffers are not properly cleaned up after they finish their job.

This PR fixes these problems.

### Reproduce steps

- Prepare this `init.vim`

  ```vim
  " Please modify these paths.
  set runtimepath+=~/.cache/nvim/lazy/denops.vim
  set runtimepath+=~/.cache/nvim/lazy/skkeleton
  set runtimepath+=~/.cache/nvim/lazy/skkeleton-state-popup

  inoremap <C-j> <Plug>(skkeleton-toggle)

  call skkeleton_state_popup#config(#{
  \   labels: {
  \     'input': #{hira: "あ", kata: 'ア', hankata: 'ｶﾅ', zenkaku: 'Ａ'},
  \     'input:okurinasi': #{hira: '▽▽', kata: '▽▽', hankata: '▽▽', abbrev: 'ab'},
  \     'input:okuriari': #{hira: '▽▽', kata: '▽▽', hankata: '▽▽'},
  \     'henkan': #{hira: '▼▼', kata: '▼▼', hankata: '▼▼', abbrev: 'ab'},
  \     'latin': '_A',
  \   },
  \   opts: #{relative: 'cursor', col: 0, row: 1, anchor: 'NW', style: 'minimal'},
  \ })
  call skkeleton_state_popup#run()
  ```

- Open Neovim by `nvim --clean -u init.vim`
- Run this command: `:ls!`
  - The output should be like this.
    ```
    :ls!
      1 %a   "[No Name]"                    line 1
    ```
- Type `q:i<C-j><ESC>:q<CR>`
  - `q:` ... Open cmdwin
  - `i<C-j><ESC>` ... Enter insert mode, activate skkkeleton, and leave insert mode
  - `:q<CR>` ... Leave cmdwin
- Run this command again: `:ls!` (\*1)
- There still be a hidden buffer (buffer 3) that seem to be created by skkeleton-state-popup.
  ```
  :ls!
    1 %a   "[No Name]"                    line 1
    3u h   "[Scratch]"                    line 1
  ```
- Run this command: `:autocmd CmdwinLeave` (\*2)
- There's still an autocmd to remove the buffer of popup by skkeleton-state-popup.
  ```
  :autocmd CmdwinLeave
  --- Autocommands ---
  CmdwinLeave
      *         call timer_start(0, { _ -> "bwipeout! 3" })
  ```

### Expected behavior

The buffer 3 is already deleted at \*1, and no autocmds are listed at \*2.
In other words (and with this PR), the command output at \*1 and \*2 should be like this:

- `:ls!` at \*1
  ```
  :ls!
    1 %a   "[No Name]"                    line 1
  Press ENTER or type command to continue
  ```
- `:autocmd CmdwinLeave` at \*2
  ```
  :autocmd CmdwinLeave
  --- Autocommands ---
  Press ENTER or type command to continue
  ```
